### PR TITLE
Calculate reduced chi2 when loading data in `NeoWisePhotometryAlertSupplier`

### DIFF
--- a/ampel/contrib/hu/alert/NeoWisePhotometryAlertSupplier.py
+++ b/ampel/contrib/hu/alert/NeoWisePhotometryAlertSupplier.py
@@ -78,8 +78,19 @@ class NeoWisePhotometryAlertSupplier(BaseAlertSupplier):
         df["W2_flux_density_ul"].replace(1.0, "True", inplace=True)
 
         if "timewise_metadata" in d[1].keys():
-            df[list(d[1]["timewise_metadata"].keys())] = pd.DataFrame(
-                list([d[1]["timewise_metadata"].values()]), index=df.index
+
+            # calculate reduced chi2
+            timewise_metadata = d[1]["timewise_metadata"]
+            for b in ["W1", "W2"]:
+                timewise_metadata[f"{b}_red_chi2"] = (
+                    timewise_metadata[f"{b}_chi2_to_med_flux_density"] /
+                    (timewise_metadata[f"{b}_N_datapoints_flux_density"] - 1)
+                    if timewise_metadata[f"{b}_N_datapoints_flux_density"] > 1
+                    else np.nan
+                )
+
+            df[list(timewise_metadata.keys())] = pd.DataFrame(
+                list([timewise_metadata.values()]), index=df.index
             )
             selected_columns_W1 = [
                 "mean_mjd",
@@ -90,7 +101,7 @@ class NeoWisePhotometryAlertSupplier(BaseAlertSupplier):
                 "W1_flux_density_rms",
                 "W1_flux_density_ul",
                 "jd",
-            ] + [col for col in list(d[1]["timewise_metadata"]) if "W1" in col]
+            ] + [col for col in list(timewise_metadata) if "W1" in col]
             selected_columns_W2 = [
                 "mean_mjd",
                 "W2_mean_mag",
@@ -100,7 +111,7 @@ class NeoWisePhotometryAlertSupplier(BaseAlertSupplier):
                 "W2_flux_density_rms",
                 "W2_flux_density_ul",
                 "jd",
-            ] + [col for col in list(d[1]["timewise_metadata"]) if "W2" in col]
+            ] + [col for col in list(timewise_metadata) if "W2" in col]
         else:
             selected_columns_W1 = [
                 "mean_mjd",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ampel-hu-astro"
-version = "0.8.3a15"
+version = "0.8.3a16"
 license = "BSD-3-Clause"
 readme = "README.md"
 description = "Astronomy units for the Ampel system from HU-Berlin"

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from setuptools import find_namespace_packages, setup
 
 setup(
     name="ampel-hu-astro",
-    version="0.8.3-alpha.14",
+    version="0.8.3-alpha.16",
     packages=find_namespace_packages(),
     package_data={
         "": ["*.json", "py.typed"],  # include any package containing *.json files


### PR DESCRIPTION
To be able to make a selection on the reduced chi2 I added a line in the `NeoWisePhotometryAlertSupplier` to calculate to from the `timewise_metadata`: `chi2_to_med_flux_density` / `N_datapoints_flux_density`