### PR TITLE
Report class unknown when ndet==0

### DIFF
--- a/ampel/contrib/hu/t2/T2ElasticcAllClassifier.py
+++ b/ampel/contrib/hu/t2/T2ElasticcAllClassifier.py
@@ -37,7 +37,7 @@ class T2ElasticcAllClassifier(BaseElasticc2Classifier):
     """
 
     # Setting for report to construct
-    classifier_name: str = 'EM'
+    classifier_name: str = 'ElasticcMonster'
     classifier_version: str = 'v231123'
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ampel-hu-astro"
-version = "0.8.3a15"
+version = "0.8.3a16"
 license = "BSD-3-Clause"
 readme = "README.md"
 description = "Astronomy units for the Ampel system from HU-Berlin"


### PR DESCRIPTION
Cases with no detection, ndet==0, looks to be much more common in test data. The default classifier looks to assume these to be AGN, but better to leave unclassified. 