### PR TITLE
Lightcurve classfix

### DIFF
--- a/ampel/contrib/hu/t2/T2BaseLightcurveFitter.py
+++ b/ampel/contrib/hu/t2/T2BaseLightcurveFitter.py
@@ -18,11 +18,10 @@ from sfdmap2.sfdmap import SFDMap  # type: ignore[import]
 
 from ampel.abstract.AbsTabulatedT2Unit import AbsTabulatedT2Unit
 from ampel.base.decorator import abstractmethod
-from ampel.content.DataPoint import DataPoint
-from ampel.content.T1Document import T1Document
 from ampel.contrib.hu.t2.T2DigestRedshifts import T2DigestRedshifts
 from ampel.struct.UnitResult import UnitResult
 from ampel.types import UBson
+from ampel.view.LightCurve import LightCurve
 from ampel.view.T2DocView import T2DocView
 
 
@@ -39,9 +38,12 @@ class T2BaseLightcurveFitter(T2DigestRedshifts, AbsTabulatedT2Unit, abstract=Tru
 
     """
 
-    # Adding default redshift selection values, corresponding to usage of "good" redshifts from catalogs
-    redshift_kind = "T2DigestRedshifts"
-    max_redshift_category: int = 3
+    # Adding default redshift selection values, corresponding to usage of "good" redshifts from catalogs can be selected
+    # Leaving to default values either provides no redshift,
+    #redshift_kind = "T2DigestRedshifts"
+    #max_redshift_category: int = 3
+    # ... or uncommenting below will provide a fixed z
+    # fixed_z: 0.1
 
     # Remove MW dust absorption.
     # MWEBV is either derived from SFD maps using the position from light_curve
@@ -116,7 +118,7 @@ class T2BaseLightcurveFitter(T2DigestRedshifts, AbsTabulatedT2Unit, abstract=Tru
 
     def get_fitdata(
         self,
-        datapoints: Sequence[DataPoint],
+        light_curve: LightCurve,
         t2_views: Sequence[T2DocView],
     ) -> tuple[Table | None, dict]:
         """
@@ -134,28 +136,6 @@ class T2BaseLightcurveFitter(T2DigestRedshifts, AbsTabulatedT2Unit, abstract=Tru
         # Fit data info
         fitdatainfo: dict[str, UBson] = {}
 
-        # Check for phase limits
-        (jdstart, jdend) = self._get_phaselimit(t2_views)
-        fitdatainfo["jdstart"] = jdstart
-        fitdatainfo["jdend"] = jdend
-        if fitdatainfo["jdstart"] is None:
-            return (None, fitdatainfo)
-
-        # Obtain photometric table
-        sncosmo_table = self.get_flux_table(datapoints)
-        sncosmo_table = sncosmo_table[
-            (sncosmo_table["time"] >= jdstart) & (sncosmo_table["time"] <= jdend)
-        ]
-
-        # Potentially correct for dust absorption
-        # Requires filters to be known by sncosmo (and the latter installed)
-        if self.apply_mwcorrection:
-            # Get ebv from coordiantes.
-            # Here there should be some option to read it from journal/stock etc
-            mwebv = self.dustmap.ebv(*self.get_pos(datapoints, which="mean"))
-            fitdatainfo["mwebv"] = mwebv
-            sncosmo_table = self._deredden_mw_extinction(mwebv, sncosmo_table)
-
         ## Obtain redshift(s) from T2DigestRedshifts
         zlist, z_source, z_weights = self.get_redshift(t2_views)
         fitdatainfo["z"] = zlist
@@ -165,6 +145,31 @@ class T2BaseLightcurveFitter(T2DigestRedshifts, AbsTabulatedT2Unit, abstract=Tru
         if not isinstance(zlist, list) or z_source is None:
             return (None, fitdatainfo)
 
+        # Check for phase limits
+        (jdstart, jdend) = self._get_phaselimit(t2_views)
+        fitdatainfo["jdstart"] = jdstart
+        fitdatainfo["jdend"] = jdend
+        if fitdatainfo["jdstart"] is None:
+            return (None, fitdatainfo)
+
+        # Obtain photometric table
+        if (pps := light_curve.get_photopoints()) is None:
+            return (None, fitdatainfo)
+
+        sncosmo_table = self.get_flux_table(pps)
+        sncosmo_table = sncosmo_table[
+            (sncosmo_table["time"] >= jdstart) & (sncosmo_table["time"] <= jdend)
+        ]
+
+        # Potentially correct for dust absorption
+        # Requires filters to be known by sncosmo (and the latter installed)
+        if self.apply_mwcorrection:
+            # Get ebv from coordiantes.
+            # Here there should be some option to read it from journal/stock etc
+            mwebv = self.dustmap.ebv(*light_curve.get_pos())
+            fitdatainfo["mwebv"] = mwebv
+            sncosmo_table = self._deredden_mw_extinction(mwebv, sncosmo_table)
+
         return (sncosmo_table, fitdatainfo)
 
     # ==================== #
@@ -173,8 +178,7 @@ class T2BaseLightcurveFitter(T2DigestRedshifts, AbsTabulatedT2Unit, abstract=Tru
     @abstractmethod
     def process(
         self,
-        compound: T1Document,
-        datapoints: Sequence[DataPoint],
+        light_curve: LightCurve,
         t2_views: Sequence[T2DocView],
     ) -> UBson | UnitResult:
         """

--- a/ampel/contrib/hu/t2/T2BaseLightcurveFitter.py
+++ b/ampel/contrib/hu/t2/T2BaseLightcurveFitter.py
@@ -40,8 +40,8 @@ class T2BaseLightcurveFitter(T2DigestRedshifts, AbsTabulatedT2Unit, abstract=Tru
 
     # Adding default redshift selection values, corresponding to usage of "good" redshifts from catalogs can be selected
     # Leaving to default values either provides no redshift,
-    #redshift_kind = "T2DigestRedshifts"
-    #max_redshift_category: int = 3
+    # redshift_kind = "T2DigestRedshifts"
+    # max_redshift_category: int = 3
     # ... or uncommenting below will provide a fixed z
     # fixed_z: 0.1
 

--- a/ampel/contrib/hu/t2/T2DemoLightcurveFitter.py
+++ b/ampel/contrib/hu/t2/T2DemoLightcurveFitter.py
@@ -12,11 +12,10 @@ from collections.abc import Sequence
 # The following three only used if correcting for MW dust
 import numpy as np
 
-from ampel.content.DataPoint import DataPoint
-from ampel.content.T1Document import T1Document
 from ampel.contrib.hu.t2.T2BaseLightcurveFitter import T2BaseLightcurveFitter
 from ampel.struct.UnitResult import UnitResult
 from ampel.types import UBson
+from ampel.view.LightCurve import LightCurve
 from ampel.view.T2DocView import T2DocView
 
 
@@ -42,8 +41,7 @@ class T2DemoLightcurveFitter(T2BaseLightcurveFitter):
 
     def process(
         self,
-        compound: T1Document,
-        datapoints: Sequence[DataPoint],
+        light_curve: LightCurve,
         t2_views: Sequence[T2DocView],
     ) -> UBson | UnitResult:
         """
@@ -64,7 +62,7 @@ class T2DemoLightcurveFitter(T2BaseLightcurveFitter):
 
         # Load photometry as table
         # fitdatainfo contains redshift, if requested
-        (sncosmo_table, fitdatainfo) = self.get_fitdata(datapoints, t2_views)
+        (sncosmo_table, fitdatainfo) = self.get_fitdata(light_curve, t2_views)
         t2_output.update(fitdatainfo)
         if sncosmo_table is None:
             return t2_output
@@ -78,7 +76,7 @@ class T2DemoLightcurveFitter(T2BaseLightcurveFitter):
                 continue
             t2_output["polyfit" + band] = list(
                 np.polyfit(
-                    sncosmo_table[i]["time"],
+                    sncosmo_table[i]["time"] - np.min(sncosmo_table[i]["time"]),
                     sncosmo_table[i]["flux"],
                     deg=self.fit_order,
                 )

--- a/ampel/contrib/hu/t2/T2DigestRedshifts.py
+++ b/ampel/contrib/hu/t2/T2DigestRedshifts.py
@@ -12,17 +12,16 @@ from typing import Any, Literal
 
 import numpy as np
 
-from ampel.abstract.AbsTiedStateT2Unit import AbsTiedStateT2Unit
-from ampel.content.DataPoint import DataPoint
-from ampel.content.T1Document import T1Document
+from ampel.abstract.AbsTiedLightCurveT2Unit import AbsTiedLightCurveT2Unit
 from ampel.enum.DocumentCode import DocumentCode
 from ampel.model.StateT2Dependency import StateT2Dependency
 from ampel.struct.UnitResult import UnitResult
 from ampel.types import UBson
+from ampel.view.LightCurve import LightCurve
 from ampel.view.T2DocView import T2DocView
 
 
-class T2DigestRedshifts(AbsTiedStateT2Unit):
+class T2DigestRedshifts(AbsTiedLightCurveT2Unit):
     """
 
     Compare potential matches from different T2 units providing redshifts.
@@ -41,7 +40,7 @@ class T2DigestRedshifts(AbsTiedStateT2Unit):
 
     # Max redshift uncertainty category: 1-7
     # (where 7 is any, and 1 only nearby spectroscopic matches)
-    max_redshift_category: int
+    max_redshift_category: int = 3
 
     # Redshift estimates associated with each region ( only rough guideline!!! )
     category_precision: list[float] = [0.0003, 0.003, 0.01, 0.02, 0.04, 0.1, 0.3]
@@ -482,8 +481,7 @@ class T2DigestRedshifts(AbsTiedStateT2Unit):
     # ==================== #
     def process(
         self,
-        compound: T1Document,
-        datapoints: Sequence[DataPoint],
+        light_curve: LightCurve,
         t2_views: Sequence[T2DocView],
     ) -> UBson | UnitResult:
         #    def process(

--- a/examples/stellar_outburst.yml
+++ b/examples/stellar_outburst.yml
@@ -1,16 +1,16 @@
-name: stellarapr17
+name: stellarmay21
 parameters:
 - name: channelname
-  value: apr17
+  value: may21
 - name: date
-  value: "2024-04-17"
+  value: "2024-05-21"
 
 mongo:
   prefix: evalOutburst
-  reset: false
+  reset: true
 
 channel:
-- name: apr17
+- name: may21
   access: [ZTF, ZTF_PUB, ZTF_PRIV]
   policy: []
 
@@ -81,16 +81,9 @@ task:
         unit: StellarFilter
       ingest:
         mux:
-          combine:
-          - state_t2:
-            - unit: T2LineFit
-              config:
-                tabulator:
-                - unit: ZTFT2Tabulator                
-            unit: ZiT1Combiner
           insert:
             point_t2:
-            - config:
+            - config: &catalog_match_config
                 catalogs:
                   NEDz:
                     keys_to_append:
@@ -129,6 +122,22 @@ task:
                 select: first
                 sort: jd
               unit: T2CatalogMatch
+          combine:
+          - state_t2:
+            - unit: T2DemoLightcurveFitter
+              config:
+                fit_order: 1
+                fixed_z: 0.
+                tabulator:
+                - unit: ZTFT2Tabulator    
+                t2_dependency:
+                - config: *catalog_match_config
+                  link_override:
+                    filter: PPSFilter
+                    select: first
+                    sort: jd
+                  unit: T2CatalogMatch
+            unit: ZiT1Combiner
           unit: ZiMongoMuxer
 
 - title: RunT2s


### PR DESCRIPTION
The previously created base/demo lightcurve fitting classes fails due to different base class of DigestRedshifts. Now all derive from LightCurve classes. 